### PR TITLE
fixed link typo in readme.md file

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,4 +50,4 @@ For example, if you are trying to get some list of accounts, you can run this.
 		return $list_accounts;
 	});
 ```
-For more information you can go to this links https://documentation.cpanel.net/display/SDK/Guide+to+cPanel+API+2sss
+For more information you can go to this links [Guide to Cpanel API 2](https://documentation.cpanel.net/display/SDK/Guide+to+cPanel+API+2)


### PR DESCRIPTION
Fixed typo in readme.md file about Guide API link. Issue #9 