### PR TITLE
Updated app->share() to app->singleton()

### DIFF
--- a/src/Gufy/CpanelWhm/CpanelWhmServiceProvider.php
+++ b/src/Gufy/CpanelWhm/CpanelWhmServiceProvider.php
@@ -30,7 +30,7 @@ class CpanelWhmServiceProvider extends ServiceProvider
     public function register()
     {
         //
-        $this->app['cpanel-whm'] = $this->app->share(function () {
+        $this->app->singleton('cpanel-whm', function(){
             return new CpanelWhm;
         });
 


### PR DESCRIPTION
Laravel 5.4 upgrade guide - The share method has been removed from the
container. This was a legacy method that has not been documented in
several years. If you are using this method, you should begin using the
singleton method instead:

Commit solves the following error:
[Symfony\Component\Debug\Exception\FatalThrowableError]
Call to undefined method Illuminate\Foundation\Application::share()