### PR TITLE
Allow multiple servers in the config file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ composer.phar
 composer.lock
 .DS_Store
 /tests/
+.idea

--- a/README.md
+++ b/README.md
@@ -50,4 +50,21 @@ For example, if you are trying to get some list of accounts, you can run this.
 		return $list_accounts;
 	});
 ```
+
+
+### Multiple Servers
+
+If you have multiple servers saved in your config file, you can access them directly using the CpanelWhm::server('arrayKey') function.
+
+Example:
+```php
+	<?php
+
+	Route::get('list-accounts',function(){
+		$list_accounts = CpanelWhm::server('example1')->listaccts();
+
+		return $list_accounts;
+	});
+```
+
 For more information you can go to this links [Guide to Cpanel API 2](https://documentation.cpanel.net/display/SDK/Guide+to+cPanel+API+2)

--- a/src/Gufy/CpanelWhm/CpanelWhm.php
+++ b/src/Gufy/CpanelWhm/CpanelWhm.php
@@ -114,6 +114,16 @@ class CpanelWhm extends Cpanel
     }
 
     /**
+     * Fetch the current hostname
+     *
+     * @return string
+     */
+    public function getHostname()
+    {
+        return $this->hostName;
+    }
+
+    /**
      * Set cPanel username and password.
      *
      * @param string $username

--- a/src/Gufy/CpanelWhm/CpanelWhm.php
+++ b/src/Gufy/CpanelWhm/CpanelWhm.php
@@ -49,6 +49,17 @@ class CpanelWhm extends Cpanel
     }
 
     /**
+     * Helper function to select server
+     *
+     * @param $server_key
+     * @return CpanelWhm
+     */
+    public static function server($server_key)
+    {
+        return new self($server_key);
+    }
+
+    /**
      * Set the config settings
      *
      * @param $server_key

--- a/src/config/config.php
+++ b/src/config/config.php
@@ -1,7 +1,8 @@
 <?php 
 return [
     'servers' => [
-        [
+        // Array key not necessary unless you have multiple servers
+        'example1' => [
             /*
             |--------------------------------------------------------------------------
             | Host of your server
@@ -10,7 +11,7 @@ return [
             | Please provide this by its full URL including its protocol and its port
             |
             */
-            'host'=>'https://127.0.0.1:2087',
+            'host' => 'https://127.0.0.1:2087',
 
             /*
             |--------------------------------------------------------------------------
@@ -22,7 +23,7 @@ return [
             | Copy and paste all of the string
             |
             */
-            'auth'=>'your_long_string_hash_key',
+            'auth' => 'your_long_string_hash_key',
 
             /*
             |--------------------------------------------------------------------------
@@ -34,7 +35,7 @@ return [
             | External API which is provided by CPanel/WHM
             |
             */
-            'username'=>'root',
+            'username' => 'root',
         ],
         // More Servers can be listed here as a new array
     ]

--- a/src/config/config.php
+++ b/src/config/config.php
@@ -1,37 +1,41 @@
 <?php 
 return [
-	/*
-	|--------------------------------------------------------------------------
-	| Host of your server
-	|--------------------------------------------------------------------------
-	|
-	| Please provide this by its full URL including its protocol and its port
-	|
-	*/
-	'host'=>'https://127.0.0.1:2087',
+    'servers' => [
+        [
+            /*
+            |--------------------------------------------------------------------------
+            | Host of your server
+            |--------------------------------------------------------------------------
+            |
+            | Please provide this by its full URL including its protocol and its port
+            |
+            */
+            'host'=>'https://127.0.0.1:2087',
 
-	/*
-	|--------------------------------------------------------------------------
-	| Remote Access key
-	|--------------------------------------------------------------------------
-	|
-	| You can find this remote access key on your CPanel/WHM server. 
-	| Log in to your server using root, and find `Remote Access Key`.
-	| Copy and paste all of the string
-	|
-	*/
-	'auth'=>'your_long_string_hash_key',
+            /*
+            |--------------------------------------------------------------------------
+            | Remote Access key
+            |--------------------------------------------------------------------------
+            |
+            | You can find this remote access key on your CPanel/WHM server.
+            | Log in to your server using root, and find `Remote Access Key`.
+            | Copy and paste all of the string
+            |
+            */
+            'auth'=>'your_long_string_hash_key',
 
-	/*
-	|--------------------------------------------------------------------------
-	| Username
-	|--------------------------------------------------------------------------
-	|
-	| By default, it will use root as its username. If you have another username,
-	| make sure it has the same privelege with the root or at least it can access
-	| External API which is provided by CPanel/WHM
-	|
-	*/
-	'username'=>'root',
-
+            /*
+            |--------------------------------------------------------------------------
+            | Username
+            |--------------------------------------------------------------------------
+            |
+            | By default, it will use root as its username. If you have another username,
+            | make sure it has the same privelege with the root or at least it can access
+            | External API which is provided by CPanel/WHM
+            |
+            */
+            'username'=>'root',
+        ],
+        // More Servers can be listed here as a new array
+    ]
 ];


### PR DESCRIPTION
Hey, I needed this for a project I'm working on.

I set it up in a way that it will support the old config file setup.
If no server is selected, it will automatically select the first one.

Also adds method to allow for getHostname, as it becomes handy when dealing with multiple servers.

If you don't want it in master, that's cool. Just cancel the request and I'll keep this maintained on my fork